### PR TITLE
Composer Tools

### DIFF
--- a/aliases.sh
+++ b/aliases.sh
@@ -6,4 +6,4 @@ alias git-reset='git reset --hard origin/$(git-current-branch)';
 alias git-clean-local-branches='git fetch --quiet && git branch -vv | grep -v  "^\*" | grep "\[.*: gone\]" | cut -d " " -f 3 | xargs git branch --delete';
 
 alias package-version='function _composer_package_version { parts=($(echo ${1%/} | tr "/" "\n")); if [[ 2 -le $#parts ]]; then vendor="${parts[-2]}/"; else vendor=''; fi; package="$vendor${parts[-1]}"; grep "\"name\": \".*$package\"" -A 5 composer.lock; }; _composer_package_version';
-alias composer-ulm='php -d memory_limit=-1 $(where composer)';
+alias composer-ulm='php -d memory_limit=-1 $(which composer)';

--- a/aliases.sh
+++ b/aliases.sh
@@ -5,4 +5,4 @@ alias git-current-tag='git fetch --tags --force --quiet && git describe --tags 2
 alias git-reset='git reset --hard origin/$(git-current-branch)';
 alias git-clean-local-branches='git fetch --quiet && git branch -vv | grep -v  "^\*" | grep "\[.*: gone\]" | cut -d " " -f 3 | xargs git branch --delete';
 
-alias package-version='function _composer_package_version { grep "\"name\": \".*$1\"" -A 5 composer.lock; }; _composer_package_version';
+alias package-version='function _composer_package_version { parts=($(echo ${1%/} | tr "/" "\n")); if [[ 2 -le $#parts ]]; then vendor="${parts[-2]}/"; else vendor=''; fi; package="$vendor${parts[-1]}"; grep "\"name\": \".*$package\"" -A 5 composer.lock; }; _composer_package_version';

--- a/aliases.sh
+++ b/aliases.sh
@@ -6,3 +6,4 @@ alias git-reset='git reset --hard origin/$(git-current-branch)';
 alias git-clean-local-branches='git fetch --quiet && git branch -vv | grep -v  "^\*" | grep "\[.*: gone\]" | cut -d " " -f 3 | xargs git branch --delete';
 
 alias package-version='function _composer_package_version { grep "\"name\": \".*$1\"" -A 5 composer.lock; }; _composer_package_version';
+alias composer-ulm='php -d memory_limit=-1 $(where composer)';

--- a/aliases.sh
+++ b/aliases.sh
@@ -4,3 +4,5 @@ alias git-current-commit='git rev-parse --verify --short HEAD';
 alias git-current-tag='git fetch --tags --force --quiet && git describe --tags 2> /dev/null';
 alias git-reset='git reset --hard origin/$(git-current-branch)';
 alias git-clean-local-branches='git fetch --quiet && git branch -vv | grep -v  "^\*" | grep "\[.*: gone\]" | cut -d " " -f 3 | xargs git branch --delete';
+
+alias package-version='function _composer_package_version { grep "\"name\": \".*$1\"" -A 1 composer.lock; }; _composer_package_version';

--- a/aliases.sh
+++ b/aliases.sh
@@ -5,4 +5,4 @@ alias git-current-tag='git fetch --tags --force --quiet && git describe --tags 2
 alias git-reset='git reset --hard origin/$(git-current-branch)';
 alias git-clean-local-branches='git fetch --quiet && git branch -vv | grep -v  "^\*" | grep "\[.*: gone\]" | cut -d " " -f 3 | xargs git branch --delete';
 
-alias package-version='function _composer_package_version { grep "\"name\": \".*$1\"" -A 1 composer.lock; }; _composer_package_version';
+alias package-version='function _composer_package_version { grep "\"name\": \".*$1\"" -A 5 composer.lock; }; _composer_package_version';


### PR DESCRIPTION
* `package-version`: search a package version in composer.lock
  - `package-version ezsystems/ezplatform-kernel;` has a shorter result than `composer show ezsystems/ezplatform-kernel;` but longer than `composer show ezsystems/ezplatform-kernel*;`
  - `package-version ezplatform-kernel;` ↔ `composer show */ezplatform-kernel;`
  - `package-version ezsystems/.*;` ↔ `composer show ezsystems/*;`
  - `package-version ezplatform-.*` ↔ ❓ ~~`composer show ezplatform-*;`~~ ~~`composer show */ezplatform-*;`~~
  - `package-version vendor/ibexa/commerce` works so auto-completion can be used.
